### PR TITLE
FIX AuthComponent  declare(strict_types=1);

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -267,7 +267,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
         /** @var \Cake\Controller\Controller $controller */
         $controller = $event->getSubject();
 
-        $action = $controller->getRequest()->getParam('action');
+        $action = $controller->getRequest()->getParam('action', '');
         if (!$controller->isAction($action)) {
             return null;
         }


### PR DESCRIPTION
Since strict_types is activated and, $controller->isAction($action) cannot receive a null (or boolean) value.
